### PR TITLE
[Feature] Add groups parameter to Conv2d in ResidualBlockNoBN

### DIFF
--- a/mmedit/models/common/sr_backbone_utils.py
+++ b/mmedit/models/common/sr_backbone_utils.py
@@ -56,11 +56,11 @@ class ResidualBlockNoBN(nn.Module):
             Default: 1.0.
     """
 
-    def __init__(self, mid_channels=64, res_scale=1.0):
+    def __init__(self, mid_channels=64, res_scale=1.0, groups=1):
         super().__init__()
         self.res_scale = res_scale
-        self.conv1 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True)
-        self.conv2 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True)
+        self.conv1 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups=1)
+        self.conv2 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups=1)
 
         self.relu = nn.ReLU(inplace=True)
 

--- a/mmedit/models/common/sr_backbone_utils.py
+++ b/mmedit/models/common/sr_backbone_utils.py
@@ -59,7 +59,7 @@ class ResidualBlockNoBN(nn.Module):
     def __init__(self, mid_channels=64, res_scale=1.0, groups=1):
         super().__init__()
         self.res_scale = res_scale
-        self.conv1 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups=1)
+        self.conv1 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups= groups)
         self.conv2 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups=1)
 
         self.relu = nn.ReLU(inplace=True)

--- a/mmedit/models/common/sr_backbone_utils.py
+++ b/mmedit/models/common/sr_backbone_utils.py
@@ -59,8 +59,10 @@ class ResidualBlockNoBN(nn.Module):
     def __init__(self, mid_channels=64, res_scale=1.0, groups=1):
         super().__init__()
         self.res_scale = res_scale
-        self.conv1 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups= groups)
-        self.conv2 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups= groups)
+        self.conv1 = nn.Conv2d(
+            mid_channels, mid_channels, 3, 1, 1, bias=True, groups=groups)
+        self.conv2 = nn.Conv2d(
+            mid_channels, mid_channels, 3, 1, 1, bias=True, groups=groups)
 
         self.relu = nn.ReLU(inplace=True)
 

--- a/mmedit/models/common/sr_backbone_utils.py
+++ b/mmedit/models/common/sr_backbone_utils.py
@@ -60,7 +60,7 @@ class ResidualBlockNoBN(nn.Module):
         super().__init__()
         self.res_scale = res_scale
         self.conv1 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups= groups)
-        self.conv2 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups=1)
+        self.conv2 = nn.Conv2d(mid_channels, mid_channels, 3, 1, 1, bias=True, groups= groups)
 
         self.relu = nn.ReLU(inplace=True)
 


### PR DESCRIPTION
**Add groups parameter to Conv2d in ResidualBlockNoBN**

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.


I'm working on implement acceleration and compression for Super Resolution model to deploy on small device.  
I have to use group convolution using conv2d groups parameter. But in mmediting ResidualBlockNoBN has no groups parameter.  
So I think groups parameter has to be add to ResidualBlockNoBN for who need group convolution.

## Modification

Please briefly describe what modification is made in this PR.

Add groups parameter to Conv2d in ResidualBlockNoBN.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
