### PR TITLE
[Fix] Enhance the compatibility of training stylegan 2

### DIFF
--- a/configs/styleganv2/stylegan2_c2_8xb4_ffhq-1024x1024.py
+++ b/configs/styleganv2/stylegan2_c2_8xb4_ffhq-1024x1024.py
@@ -42,7 +42,7 @@ optim_wrapper = dict(
                                                         0.99**d_reg_ratio))))
 
 batch_size = 4
-data_root = 's3://openmmlab/datasets/editing/ffhq/images'
+data_root = './data/ffhq/images'
 
 train_dataloader = dict(
     batch_size=batch_size, dataset=dict(data_root=data_root))

--- a/configs/styleganv2/stylegan2_c2_8xb4_ffhq-1024x1024.py
+++ b/configs/styleganv2/stylegan2_c2_8xb4_ffhq-1024x1024.py
@@ -42,7 +42,7 @@ optim_wrapper = dict(
                                                         0.99**d_reg_ratio))))
 
 batch_size = 4
-data_root = './data/ffhq/images'
+data_root = 's3://openmmlab/datasets/editing/ffhq/images'
 
 train_dataloader = dict(
     batch_size=batch_size, dataset=dict(data_root=data_root))

--- a/mmedit/models/base_archs/conv2d_gradfix.py
+++ b/mmedit/models/base_archs/conv2d_gradfix.py
@@ -240,7 +240,7 @@ def _conv2d_gradfix(transpose, weight_shape, stride, padding, output_padding,
                     memory_format=(torch.channels_last if input.stride(1) ==
                                    1 else torch.contiguous_format))
             
-            # PyTorch conslidated convolution backward API in PR:
+            # PyTorch consolidated convolution backward API in PR:
             # https://github.com/pytorch/pytorch/commit/3dc3651e0ee3623f669c3a2c096408dbc476d122  # noqa: E501
             # Enhance the code referring to the discussion:
             # https://github.com/pytorch/pytorch/issues/74437

--- a/mmedit/models/base_archs/conv2d_gradfix.py
+++ b/mmedit/models/base_archs/conv2d_gradfix.py
@@ -11,6 +11,7 @@ arbitrarily high order gradients with zero performance penalty."""
 import contextlib
 
 import torch
+from mmengine.utils import digit_version
 
 enabled = True
 weight_gradients_disabled = False
@@ -238,18 +239,36 @@ def _conv2d_gradfix(transpose, weight_shape, stride, padding, output_padding,
                 return c.contiguous(
                     memory_format=(torch.channels_last if input.stride(1) ==
                                    1 else torch.contiguous_format))
-
-            # General case => cuDNN.
-            name = ('aten::cudnn_convolution_transpose_backward_weight' if
+            
+            # PyTorch conslidated convolution backward API in PR:
+            # https://github.com/pytorch/pytorch/commit/3dc3651e0ee3623f669c3a2c096408dbc476d122  # noqa: E501
+            # Enhance the code referring to the discussion:
+            # https://github.com/pytorch/pytorch/issues/74437
+            if digit_version(torch.__version__) >= digit_version('1.11.0'):
+                empty_weight = torch.empty(
+                    weight_shape, dtype=input.dtype, layout=input.layout,
+                    device=input.device)
+                output_padding = calc_output_padding(
+                    input.shape, grad_output.shape)
+                return torch.ops.aten.convolution_backward(
+                    grad_output, input, empty_weight, None, stride=stride,
+                    dilation=dilation, transposed=transpose, padding=padding,
+                    groups=groups, output_padding=output_padding,
+                    output_mask=[0, 1, 0]
+                )[1]
+            else:
+                # General case => cuDNN.
+                name = (
+                    'aten::cudnn_convolution_transpose_backward_weight' if
                     transpose else 'aten::cudnn_convolution_backward_weight')
-            flags = [
-                torch.backends.cudnn.benchmark,
-                torch.backends.cudnn.deterministic,
-                torch.backends.cudnn.allow_tf32
-            ]
-            return torch._C._jit_get_operation(name)(weight_shape, grad_output,
-                                                     input, padding, stride,
-                                                     dilation, groups, *flags)
+                flags = [
+                    torch.backends.cudnn.benchmark,
+                    torch.backends.cudnn.deterministic,
+                    torch.backends.cudnn.allow_tf32
+                ]
+                return torch._C._jit_get_operation(name)(
+                    weight_shape, grad_output, input, padding, stride,
+                    dilation, groups, *flags)
 
         @staticmethod
         def backward(ctx, grad2_grad_weight):


### PR DESCRIPTION
## Motivation

PyTorch consolidated convolution backward API in [PR](https://github.com/pytorch/pytorch/commit/3dc3651e0ee3623f669c3a2c096408dbc476d122). It means users cannot train styegan2 with PyTorch version higher than 1.10.1

This PR enhances the compatibility of the code referring to the [discussion](https://github.com/pytorch/pytorch/issues/74437)

Resolve [#3](https://github.com/open-mmlab/mmgeneration/issues/322)

## Modification

Please briefly describe what modification is made in this PR.

## Who can help? @ them here!

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
