### PR TITLE
[Fix] Typos and mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ Please refer to [migration documents](docs/en/migration/overview.md) to migrate 
 
 - [📖 Introduction](#-introduction)
 - [🙌 Contributing](#-contributing)
-- [🛠️ Installation](#%EF%B8%8F-installation)
+- [🛠️ Installation](#️-installation)
 - [📊 Model Zoo](#-model-zoo)
 - [🤝 Acknowledgement](#-acknowledgement)
-- [🖊️ Citation](#%EF%B8%8F-citation)
+- [🖊️ Citation](#️-citation)
 - [🎫 License](#-license)
-- [🏗️ ️OpenMMLab Family](#%EF%B8%8F-️openmmlab-family)
+- [🏗️ ️OpenMMLab Family](#️-️openmmlab-family)
 
 <p align="right"><a href="#top">🔝Back to top</a></p>
 
@@ -371,7 +371,7 @@ Please refer to [installation](docs/en/get_started/install.md) for more detailed
         <ul>
           <li><a href="configs/dim/README.md">DIM (CVPR'2017)</a></li>
           <li><a href="configs/indexnet/README.md">IndexNet (ICCV'2019)</a></li>
-          <li><a href="configs/mask2former">GCA (AAAI'2020)</a></li>
+          <li><a href="configs/gca/README.md">GCA (AAAI'2020)</a></li>
         </ul>
       </td>
       <td>

--- a/docs/en/howto/models.md
+++ b/docs/en/howto/models.md
@@ -430,7 +430,7 @@ We also need to specify the training dataloader and testing dataloader according
 Finally we can start training our own model by：
 
 ```python
-python train.py configs/srcnn/srcnn_x4k915_g1_1000k_div2k.py
+python tools/train.py configs/srcnn/srcnn_x4k915_g1_1000k_div2k.py
 ```
 
 ## An example of DCGAN
@@ -738,7 +738,7 @@ We also need to specify the training dataloader and testing dataloader according
 Finally we can start training our own model by：
 
 ```python
-python train.py configs/dcgan/dcgan_1xb128-5epoches_lsun-bedroom-64x64.py
+python tools/train.py configs/dcgan/dcgan_1xb128-5epoches_lsun-bedroom-64x64.py
 ```
 
 ## References

--- a/docs/en/user_guides/config.md
+++ b/docs/en/user_guides/config.md
@@ -481,7 +481,7 @@ custom_hooks = [
 ### Runtime config
 
 ```python
-default_scope = 'mmagic'  # The default registry scope to find modules. Refer to https://mmengine.readthedocs.io/en/latest/tutorials/registry.html
+default_scope = 'mmagic'  # The default registry scope to find modules. Refer to https://mmengine.readthedocs.io/en/latest/advanced_tutorials/registry.html
 
 # config for environment
 env_cfg = dict(

--- a/docs/zh_cn/howto/models.md
+++ b/docs/zh_cn/howto/models.md
@@ -413,7 +413,7 @@ model = dict(
 最后，我们可以开始训练我们自己的模型:
 
 ```python
-python train.py configs/srcnn/srcnn_x4k915_g1_1000k_div2k.py
+python tools/train.py configs/srcnn/srcnn_x4k915_g1_1000k_div2k.py
 ```
 
 ## 一个DCGAN的例子
@@ -720,7 +720,7 @@ model = dict(
 最后，我们可以开始训练我们自己的模型:
 
 ```python
-python train.py configs/dcgan/dcgan_1xb128-5epoches_lsun-bedroom-64x64.py
+python tools/train.py configs/dcgan/dcgan_1xb128-5epoches_lsun-bedroom-64x64.py
 ```
 
 ## 参考文献

--- a/mmagic/registry.py
+++ b/mmagic/registry.py
@@ -5,7 +5,7 @@ MMagic provides 17 registry nodes to support using modules across projects.
 Each node is a child of the root registry in MMEngine.
 
 More details can be found at
-https://mmengine.readthedocs.io/en/latest/tutorials/registry.html.
+https://mmengine.readthedocs.io/en/latest/advanced_tutorials/registry.html.
 """
 
 from mmengine.registry import DATA_SAMPLERS as MMENGINE_DATA_SAMPLERS

--- a/mmagic/utils/setup_env.py
+++ b/mmagic/utils/setup_env.py
@@ -17,7 +17,7 @@ def register_all_modules(init_default_scope: bool = True) -> None:
             set to `mmagic`, and all registries will build modules from
             mmagic's registry node.
             To understand more about the registry, please refer
-            to https://github.com/open-mmlab/mmengine/blob/main/docs/en/tutorials/registry.md
+            to https://mmengine.readthedocs.io/en/latest/advanced_tutorials/registry.html
             Defaults to True.
     """  # noqa
     import mmagic.datasets  # noqa: F401,F403

--- a/projects/flow_style_vton/inference.py
+++ b/projects/flow_style_vton/inference.py
@@ -11,7 +11,7 @@ from vton_dataset import AlignedDataset
 from mmagic.apis.inferencers.inference_functions import init_model
 from projects.flow_style_vton.models import FlowStyleVTON
 
-init_default_scope('mmedit')
+init_default_scope('mmagic')
 
 config = 'configs/flow_style_vton_PFAFN_epoch_101.py'
 


### PR DESCRIPTION
1. Fix README TOC typos.
2. Fix README GCA link.
3. Change "train.py" to "tools/train.py".
4. Change "tutorials/registry.html" to "advanced_tutorials/registry.html".
5. Change the default scope from "mmedit" to "mmagic".