### PR TITLE
[Fix] Requirements

### DIFF
--- a/mmagic/__init__.py
+++ b/mmagic/__init__.py
@@ -20,7 +20,7 @@ except ImportError:
         return digit_ver
 
 
-MMCV_MIN = '2.0.0rc1'
+MMCV_MIN = '2.0.0'
 MMCV_MAX = '2.1.0'
 mmcv_min_version = digit_version(MMCV_MIN)
 mmcv_max_version = digit_version(MMCV_MAX)

--- a/requirements/mminstall.txt
+++ b/requirements/mminstall.txt
@@ -1,2 +1,2 @@
-mmcv>=2.0.0
+mmcv>=2.0.0rc1
 mmengine>=0.4.0

--- a/requirements/mminstall.txt
+++ b/requirements/mminstall.txt
@@ -1,2 +1,2 @@
-mmcv>=2.0.0rc1
+mmcv>=2.0.0
 mmengine>=0.4.0

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,6 @@
 av
 av==8.0.3; python_version < '3.7'
+Click  # required by mmagic/utils/io_utils.py
 controlnet_aux
 diffusers>=0.12.0
 einops
@@ -8,10 +9,9 @@ facexlib
 lmdb
 lpips
 mediapipe
-mmcv>=2.0.0rc1
-mmengine
 numpy
 opencv-python!=4.5.5.62,!=4.5.5.64
+pandas  # required by mmagic/models/editors/disco_diffusion/guider.py
 # MMCV depends opencv-python instead of headless, thus we install opencv-python
 # Due to a bug from upstream, we skip this two version
 # https://github.com/opencv/opencv-python/issues/602

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,6 @@
 av
 av==8.0.3; python_version < '3.7'
-Click  # required by mmagic/utils/io_utils.py
+click  # required by mmagic/utils/io_utils.py
 controlnet_aux
 diffusers>=0.12.0
 einops
@@ -10,13 +10,13 @@ lmdb
 lpips
 mediapipe
 numpy
-opencv-python!=4.5.5.62,!=4.5.5.64
-pandas  # required by mmagic/models/editors/disco_diffusion/guider.py
 # MMCV depends opencv-python instead of headless, thus we install opencv-python
 # Due to a bug from upstream, we skip this two version
 # https://github.com/opencv/opencv-python/issues/602
 # https://github.com/opencv/opencv/issues/21366
 # It seems to be fixed in https://github.com/opencv/opencv/pull/21382
+opencv-python!=4.5.5.62,!=4.5.5.64
+pandas  # required by mmagic/models/editors/disco_diffusion/guider.py
 Pillow
 resize_right
 tensorboard


### PR DESCRIPTION
## Remove `mmcv` and `mmengine` from "requirements/runtime.txt"

`mmcv` and `mmengine` are repeatedly listed in "requirements/{mminstall.txt,runtime.txt}". Following [MMDetection](https://github.com/open-mmlab/mmdetection/tree/main/requirements), we removed `mmcv` and `mmengine` from "requirements/runtime.txt", and kept those in "requirements/mminstall.txt".

The reason is that we have manually installed MMCV and MMEngine before installing MMagic as indicated in the [Doc](https://github.com/open-mmlab/mmagic/blob/main/docs/en/get_started/install.md). As a result, there is no need to require `mmcv` and `mmengine` in "requirements/runtime.txt", which are to be installed with "setup.py".

After this modification, the installation of MMagic is much faster.

## Add dependencies Click and pandas in "requirements/runtime.txt"

We added `Click` and `pandas` in "requirements/runtime.txt". They are required by "mmagic/utils/io_utils.py" and "mmagic/models/editors/disco_diffusion/guider.py".

These two packages are installed when installing [MIM](https://github.com/open-mmlab/mim/blob/main/requirements/install.txt). However, when someone uses pip instead of MIM to install MMCV, these two packages are missed and cannot be found.