### PR TITLE
[Docs] Translate `migration/overview.md` into Chinese and fix some typos

### DIFF
--- a/docs/en/migration/overview.md
+++ b/docs/en/migration/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-This section introduce the following contents in terms of migration from MMEditing 0.x
+This section introduces the following contents in terms of migration from MMEditing 0.x
 
 - [Overview](#overview)
   - [New dependencies](#new-dependencies)
@@ -9,18 +9,18 @@ This section introduce the following contents in terms of migration from MMEditi
 
 ## New dependencies
 
-MMagic 1.x depends on some new packages, you can prepare a new clean environment and install again according to the [install tutorial](../get_started/install.md).
+MMagic 1.x depends on some new packages, you can prepare a new clean environment and install it again according to the [install tutorial](../get_started/install.md).
 
 ## Overall structures
 
-We refactor overall structures in MMagic 1.x as following.
+We refactor overall structures in MMagic 1.x as follows.
 
 - The  `core` in the old versions of MMEdit is split into `engine`, `evaluation`, `structures`, and `visualization`
 - The `pipelines` of `datasets` in the old versions of MMEdit is refactored to `transforms`
-- The `models` in MMagic 1.x is refactored to six parts: `archs`, `base_models`, `data_preprocessors`, `editors`, `diffusion_schedulers` and `losses`.
+- The `models` in MMagic 1.x is refactored to six parts: `archs`, `base_models`, `data_preprocessors`, `editors`, `diffusion_schedulers`, and `losses`.
 
 ## Other config settings
 
-We rename config file to new template: `{model_settings}_{module_setting}_{training_setting}_{datasets_info}`.
+We rename the config file to the new template: `{model_settings}_{module_setting}_{training_setting}_{datasets_info}`.
 
 More details of config are shown in [config guides](../user_guides/config.md).

--- a/docs/zh_cn/migration/overview.md
+++ b/docs/zh_cn/migration/overview.md
@@ -1,1 +1,26 @@
-# 概览（待更新）
+# 概览
+
+本节将从以下几个方面介绍如何从 MMEditing 0.x 迁移至 MMagic 1.x：
+
+- [概览](#概览)
+  - [新依赖项](#新依赖项)
+  - [总体结构](#总体结构)
+  - [其他配置设置](#其他配置设置)
+
+## 新依赖项
+
+MMagic 1.x 依赖于一些新的包，您可以按照[安装教程](../get_started/install.md)准备一个新的干净环境并重新安装。
+
+## 总体结构
+
+我们在 MMagic 1.x 中对总体结构进行了重构，具体如下：
+
+- 旧版本 MMEdit 中的 `core` 被拆分为 `engine`、`evaluation`、`structures` 和 `visualization`
+- 旧版本 MMEdit 中 `datasets` 的 `pipelines` 被重构为 `transforms`
+- MMagic 1.x 中的 `models` 被重构为六个部分：`archs`、`base_models`、`data_preprocessors`、`editors`、`diffusion_schedulers` 和 `losses`。
+
+## 其他配置设置
+
+我们将配置文件重命名为新模板：`{model_settings}_{module_setting}_{training_setting}_{datasets_info}`。
+
+更多配置细节请参见[配置指南](../user_guides/config.md)。


### PR DESCRIPTION
## Motivation

Translate `migration/overview.md` into Chinese and fix some typos

## Modification

1. Translate `migration/overview.md` into Chinese
2. Add missing blanks in `zh_cn/migration/amp.md`
3. Fix some typos in `en/migration/overview.md`