### PR TITLE
revise default args for unit test

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -63,7 +63,7 @@ jobs:
             pip install -U openmim
             mim install 'mmcv >= 2.0.0'
             pip install -r requirements/tests.txt
-            pip install scipy==1.11.1
+            pip install scipy==1.7.2
       - run:
           name: Build and install
           command: |
@@ -107,7 +107,7 @@ jobs:
             docker exec mmagic pip install -U openmim
             docker exec mmagic mim install 'mmcv >= 2.0.0'
             docker exec mmagic pip install -r requirements/tests.txt
-            docker exec mmagic pip install 'scipy == 1.11.1'
+            docker exec mmagic pip install 'scipy == 1.7.2'
       - run:
           name: Build and install
           command: |

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -63,6 +63,7 @@ jobs:
             pip install -U openmim
             mim install 'mmcv >= 2.0.0'
             pip install -r requirements/tests.txt
+            pip install scipy==1.11.1
       - run:
           name: Build and install
           command: |
@@ -106,6 +107,7 @@ jobs:
             docker exec mmagic pip install -U openmim
             docker exec mmagic mim install 'mmcv >= 2.0.0'
             docker exec mmagic pip install -r requirements/tests.txt
+            docker exec mmagic pip install 'scipy == 1.11.1'
       - run:
           name: Build and install
           command: |

--- a/tests/test_models/test_archs/test_wrapper.py
+++ b/tests/test_models/test_archs/test_wrapper.py
@@ -40,7 +40,10 @@ class TestWrapper(TestCase):
         self.assertIn(f'From Config: {config_path}', model_str)
 
         # 2. test save as diffuser
-        model.save_pretrained(model_path)
+        if digit_version(TORCH_VERSION) < digit_version('2.0.1'):
+            model.save_pretrained(model_path, safe_serialization=False)
+        else:
+            model.save_pretrained(model_path)
 
         # 3. test from_pretrained
         model = MODELS.build(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In https://github.com/huggingface/diffusers/commit/029fb41695a7940c213d914471fb41a1df67aa17, `diffusers` changed the default parameter of 'safe_serialization' to True in the `ModelMixin.save_pretrained` function. This make `diffusers` use `safetensors` to save model checkpoint, which need `torch >= 2.0.1`.

## Modification

Add `safe_serialization=False` in unit test.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

Submitting this pull request means that,

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.