### PR TITLE
[CodeCamp2023-643] Add new configs of BigGAN

### DIFF
--- a/mmagic/configs/_base_/datasets/cifar10_noaug.py
+++ b/mmagic/configs/_base_/datasets/cifar10_noaug.py
@@ -1,0 +1,27 @@
+cifar_pipeline = [dict(type='PackInputs')]
+cifar_dataset = dict(
+    type='CIFAR10',
+    data_root='./data',
+    data_prefix='cifar10',
+    test_mode=False,
+    pipeline=cifar_pipeline)
+
+train_dataloader = dict(
+    num_workers=2,
+    dataset=cifar_dataset,
+    sampler=dict(type='InfiniteSampler', shuffle=True),
+    persistent_workers=True)
+
+val_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    dataset=cifar_dataset,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    persistent_workers=True)
+
+test_dataloader = dict(
+    batch_size=32,
+    num_workers=2,
+    dataset=cifar_dataset,
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    persistent_workers=True)

--- a/mmagic/configs/_base_/datasets/cifar10_noaug.py
+++ b/mmagic/configs/_base_/datasets/cifar10_noaug.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 cifar_pipeline = [dict(type='PackInputs')]
 cifar_dataset = dict(
     type='CIFAR10',

--- a/mmagic/configs/_base_/datasets/imagenet_noaug_128.py
+++ b/mmagic/configs/_base_/datasets/imagenet_noaug_128.py
@@ -1,0 +1,46 @@
+# dataset settings
+dataset_type = 'ImageNet'
+
+# different from mmcls, we adopt the setting used in BigGAN.
+# Remove `RandomFlip` augmentation and change `RandomCropLongEdge` to
+# `CenterCropLongEdge` to eliminate randomness.
+# dataset settings
+train_pipeline = [
+    dict(type='LoadImageFromFile', key='img'),
+    dict(type='CenterCropLongEdge'),
+    dict(type='Resize', scale=(128, 128), backend='pillow'),
+    dict(type='PackInputs')
+]
+
+test_pipeline = [
+    dict(type='LoadImageFromFile', key='img'),
+    dict(type='CenterCropLongEdge'),
+    dict(type='Resize', scale=(128, 128), backend='pillow'),
+    dict(type='PackInputs')
+]
+
+train_dataloader = dict(
+    batch_size=None,
+    num_workers=5,
+    dataset=dict(
+        type=dataset_type,
+        data_root='data/imagenet',
+        ann_file='meta/train.txt',
+        data_prefix='train',
+        pipeline=train_pipeline),
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    persistent_workers=True)
+
+val_dataloader = dict(
+    batch_size=64,
+    num_workers=5,
+    dataset=dict(
+        type=dataset_type,
+        data_root='./data/imagenet/',
+        ann_file='meta/train.txt',
+        data_prefix='train',
+        pipeline=test_pipeline),
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    persistent_workers=True)
+
+test_dataloader = val_dataloader

--- a/mmagic/configs/_base_/datasets/imagenet_noaug_128.py
+++ b/mmagic/configs/_base_/datasets/imagenet_noaug_128.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 # dataset settings
 dataset_type = 'ImageNet'
 

--- a/mmagic/configs/_base_/models/biggan/base_biggan_128x128.py
+++ b/mmagic/configs/_base_/models/biggan/base_biggan_128x128.py
@@ -1,0 +1,28 @@
+model = dict(
+    type='BigGAN',
+    num_classes=1000,
+    data_preprocessor=dict(type='DataPreprocessor'),
+    generator=dict(
+        type='BigGANGenerator',
+        output_scale=128,
+        noise_size=120,
+        num_classes=1000,
+        base_channels=96,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        act_cfg=dict(type='ReLU', inplace=True),
+        split_noise=True,
+        auto_sync_bn=False,
+        init_cfg=dict(type='ortho')),
+    discriminator=dict(
+        type='BigGANDiscriminator',
+        input_scale=128,
+        num_classes=1000,
+        base_channels=96,
+        sn_eps=1e-6,
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True,
+        init_cfg=dict(type='ortho')),
+    generator_steps=1,
+    discriminator_steps=1)

--- a/mmagic/configs/_base_/models/biggan/base_biggan_128x128.py
+++ b/mmagic/configs/_base_/models/biggan/base_biggan_128x128.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 model = dict(
     type='BigGAN',
     num_classes=1000,

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face-rgb_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face-rgb_imagenet1k-128x128.py
@@ -1,0 +1,67 @@
+from mmengine.config import read_base
+
+from mmagic.evaluation.metrics import FrechetInceptionDistance
+from mmagic.models.data_preprocessors import DataPreprocessor
+from mmagic.models.editors.biggan import (BigGAN, BigGANDeepDiscriminator,
+                                          BigGANGenerator)
+
+with read_base():
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
+
+ema_config = dict(
+    type='ExponentialMovingAverage',
+    interval=1,
+    momentum=0.0001,
+    update_buffers=True,
+    start_iter=20000)
+
+model = dict(
+    type=BigGAN,
+    num_classes=1000,
+    data_preprocessor=dict(type=DataPreprocessor),
+    ema_config=ema_config,
+    generator=dict(
+        type=BigGANGenerator,
+        output_scale=128,
+        noise_size=128,
+        num_classes=1000,
+        base_channels=128,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        sn_style='torch',
+        act_cfg=dict(type='ReLU', inplace=True),
+        concat_noise=True,
+        auto_sync_bn=False,
+        rgb2bgr=True,
+        init_cfg=dict(type='ortho')),
+    discriminator=dict(
+        type=BigGANDeepDiscriminator,
+        input_scale=128,
+        num_classes=1000,
+        base_channels=128,
+        sn_eps=1e-6,
+        sn_style='torch',
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True,
+        init_cfg=dict(type='ortho')))
+
+train_cfg = train_dataloader = optim_wrapper = None
+
+metrics = [
+    dict(
+        type=FrechetInceptionDistance,
+        prefix='FID-Full-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema'),
+    dict(
+        type='IS',
+        prefix='IS-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema')
+]
+val_evaluator = dict(metrics=metrics)
+test_evaluator = dict(metrics=metrics)

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face-rgb_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face-rgb_imagenet1k-128x128.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 from mmengine.config import read_base
 
 from mmagic.evaluation.metrics import FrechetInceptionDistance

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face-rgb_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face-rgb_imagenet1k-128x128.py
@@ -7,8 +7,8 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDeepDiscriminator,
                                           BigGANGenerator)
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
-    from .._base_.gen_default_runtime import *  # noqa: F401,F403
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
 
 ema_config = dict(
     type='ExponentialMovingAverage',

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face-rgb_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face-rgb_imagenet1k-128x128.py
@@ -7,8 +7,8 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDeepDiscriminator,
                                           BigGANGenerator)
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *
-    from .._base_.gen_default_runtime import *
+    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
+    from .._base_.gen_default_runtime import *  # noqa: F401,F403
 
 ema_config = dict(
     type='ExponentialMovingAverage',

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-256x256.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-256x256.py
@@ -7,13 +7,13 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
                                           BigGANGenerator)
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *
-    from .._base_.gen_default_runtime import *
+    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
+    from .._base_.gen_default_runtime import *  # noqa: F401,F403
 
 # setting image size to 256x256
-train_dataloader.dataset.pipeline[2].scale = (256, 256)
-test_dataloader.dataset.pipeline[2].scale = (256, 256)
-val_dataloader.dataset.pipeline[2].scale = (256, 256)
+train_dataloader.dataset.pipeline[2].scale = (256, 256)  # noqa: F405
+test_dataloader.dataset.pipeline[2].scale = (256, 256)  # noqa: F405
+val_dataloader.dataset.pipeline[2].scale = (256, 256)  # noqa: F405
 
 ema_config = dict(
     type='ExponentialMovingAverage',

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-256x256.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-256x256.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 from mmengine.config import read_base
 
 from mmagic.evaluation.metrics import FrechetInceptionDistance

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-256x256.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-256x256.py
@@ -7,13 +7,13 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
                                           BigGANGenerator)
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
-    from .._base_.gen_default_runtime import *  # noqa: F401,F403
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
 
 # setting image size to 256x256
-train_dataloader.dataset.pipeline[2].scale = (256, 256)  # noqa: F405
-test_dataloader.dataset.pipeline[2].scale = (256, 256)  # noqa: F405
-val_dataloader.dataset.pipeline[2].scale = (256, 256)  # noqa: F405
+train_dataloader.dataset.pipeline[2].scale = (256, 256)
+test_dataloader.dataset.pipeline[2].scale = (256, 256)
+val_dataloader.dataset.pipeline[2].scale = (256, 256)
 
 ema_config = dict(
     type='ExponentialMovingAverage',

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-256x256.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-256x256.py
@@ -1,0 +1,72 @@
+from mmengine.config import read_base
+
+from mmagic.evaluation.metrics import FrechetInceptionDistance
+from mmagic.models.data_preprocessors import DataPreprocessor
+from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
+                                          BigGANGenerator)
+
+with read_base():
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
+
+# setting image size to 256x256
+train_dataloader.dataset.pipeline[2].scale = (256, 256)
+test_dataloader.dataset.pipeline[2].scale = (256, 256)
+val_dataloader.dataset.pipeline[2].scale = (256, 256)
+
+ema_config = dict(
+    type='ExponentialMovingAverage',
+    interval=1,
+    momentum=0.0001,
+    update_buffers=True,
+    start_iter=20000)
+
+model = dict(
+    type=BigGAN,
+    num_classes=1000,
+    data_preprocessor=dict(type=DataPreprocessor),
+    ema_config=ema_config,
+    generator=dict(
+        type=BigGANGenerator,
+        output_scale=256,
+        noise_size=128,
+        num_classes=1000,
+        base_channels=128,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        sn_style='torch',
+        act_cfg=dict(type='ReLU', inplace=True),
+        concat_noise=True,
+        auto_sync_bn=False,
+        rgb2bgr=True,
+        init_cfg=dict(type='ortho')),
+    discriminator=dict(
+        type=BigGANDiscriminator,
+        input_scale=256,
+        num_classes=1000,
+        base_channels=128,
+        sn_eps=1e-6,
+        sn_style='torch',
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True,
+        init_cfg=dict(type='ortho')))
+
+train_cfg = train_dataloader = optim_wrapper = None
+
+metrics = [
+    dict(
+        type=FrechetInceptionDistance,
+        prefix='FID-Full-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema'),
+    dict(
+        type='IS',
+        prefix='IS-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema')
+]
+val_evaluator = dict(metrics=metrics)
+test_evaluator = dict(metrics=metrics)

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-512x512.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-512x512.py
@@ -7,13 +7,13 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
                                           BigGANGenerator)
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *
-    from .._base_.gen_default_runtime import *
+    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
+    from .._base_.gen_default_runtime import *  # noqa: F401,F403
 
 # setting image size to 512x512
-train_dataloader.dataset.pipeline[2].scale = (512, 512)
-test_dataloader.dataset.pipeline[2].scale = (512, 512)
-val_dataloader.dataset.pipeline[2].scale = (512, 512)
+train_dataloader.dataset.pipeline[2].scale = (512, 512)  # noqa: F405
+test_dataloader.dataset.pipeline[2].scale = (512, 512)  # noqa: F405
+val_dataloader.dataset.pipeline[2].scale = (512, 512)  # noqa: F405
 
 ema_config = dict(
     type='ExponentialMovingAverage',

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-512x512.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-512x512.py
@@ -1,0 +1,72 @@
+from mmengine.config import read_base
+
+from mmagic.evaluation.metrics import FrechetInceptionDistance
+from mmagic.models.data_preprocessors import DataPreprocessor
+from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
+                                          BigGANGenerator)
+
+with read_base():
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
+
+# setting image size to 512x512
+train_dataloader.dataset.pipeline[2].scale = (512, 512)
+test_dataloader.dataset.pipeline[2].scale = (512, 512)
+val_dataloader.dataset.pipeline[2].scale = (512, 512)
+
+ema_config = dict(
+    type='ExponentialMovingAverage',
+    interval=1,
+    momentum=0.0001,
+    update_buffers=True,
+    start_iter=20000)
+
+model = dict(
+    type=BigGAN,
+    num_classes=1000,
+    data_preprocessor=dict(type=DataPreprocessor),
+    ema_config=ema_config,
+    generator=dict(
+        type=BigGANGenerator,
+        output_scale=512,
+        noise_size=128,
+        num_classes=1000,
+        base_channels=128,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        sn_style='torch',
+        act_cfg=dict(type='ReLU', inplace=True),
+        concat_noise=True,
+        auto_sync_bn=False,
+        rgb2bgr=True,
+        init_cfg=dict(type='ortho')),
+    discriminator=dict(
+        type=BigGANDiscriminator,
+        input_scale=512,
+        num_classes=1000,
+        base_channels=128,
+        sn_eps=1e-6,
+        sn_style='torch',
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True,
+        init_cfg=dict(type='ortho')))
+
+train_cfg = train_dataloader = optim_wrapper = None
+
+metrics = [
+    dict(
+        type=FrechetInceptionDistance,
+        prefix='FID-Full-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema'),
+    dict(
+        type='IS',
+        prefix='IS-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema')
+]
+val_evaluator = dict(metrics=metrics)
+test_evaluator = dict(metrics=metrics)

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-512x512.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-512x512.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 from mmengine.config import read_base
 
 from mmagic.evaluation.metrics import FrechetInceptionDistance

--- a/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-512x512.py
+++ b/mmagic/configs/biggan/biggan-deep_cvt-hugging-face_rgb_imagenet1k-512x512.py
@@ -7,13 +7,13 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
                                           BigGANGenerator)
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
-    from .._base_.gen_default_runtime import *  # noqa: F401,F403
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
 
 # setting image size to 512x512
-train_dataloader.dataset.pipeline[2].scale = (512, 512)  # noqa: F405
-test_dataloader.dataset.pipeline[2].scale = (512, 512)  # noqa: F405
-val_dataloader.dataset.pipeline[2].scale = (512, 512)  # noqa: F405
+train_dataloader.dataset.pipeline[2].scale = (512, 512)
+test_dataloader.dataset.pipeline[2].scale = (512, 512)
+val_dataloader.dataset.pipeline[2].scale = (512, 512)
 
 ema_config = dict(
     type='ExponentialMovingAverage',

--- a/mmagic/configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py
+++ b/mmagic/configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 from mmengine.config import read_base
 
 from mmagic.engine import VisualizationHook

--- a/mmagic/configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py
+++ b/mmagic/configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py
@@ -10,8 +10,8 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
 # define model
 
 with read_base():
-    from .._base_.datasets.cifar10_noaug import *
-    from .._base_.gen_default_runtime import *
+    from .._base_.datasets.cifar10_noaug import *  # noqa: F401,F403
+    from .._base_.gen_default_runtime import *  # noqa: F401,F403
 ema_config = dict(
     type='ExponentialMovingAverage',
     interval=1,

--- a/mmagic/configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py
+++ b/mmagic/configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py
@@ -10,8 +10,8 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
 # define model
 
 with read_base():
-    from .._base_.datasets.cifar10_noaug import *  # noqa: F401,F403
-    from .._base_.gen_default_runtime import *  # noqa: F401,F403
+    from .._base_.datasets.cifar10_noaug import *
+    from .._base_.gen_default_runtime import *
 ema_config = dict(
     type='ExponentialMovingAverage',
     interval=1,

--- a/mmagic/configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py
+++ b/mmagic/configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py
@@ -1,0 +1,94 @@
+from mmengine.config import read_base
+
+from mmagic.engine import VisualizationHook
+from mmagic.evaluation.metrics import FrechetInceptionDistance
+from mmagic.models.data_preprocessors import DataPreprocessor
+from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
+                                          BigGANGenerator)
+
+# define model
+
+with read_base():
+    from .._base_.datasets.cifar10_noaug import *
+    from .._base_.gen_default_runtime import *
+ema_config = dict(
+    type='ExponentialMovingAverage',
+    interval=1,
+    momentum=0.0001,
+    start_iter=1000)
+
+model = dict(
+    type=BigGAN,
+    num_classes=10,
+    data_preprocessor=dict(type=DataPreprocessor, output_channel_order='BGR'),
+    generator=dict(
+        type=BigGANGenerator,
+        output_scale=32,
+        noise_size=128,
+        num_classes=10,
+        base_channels=64,
+        with_shared_embedding=False,
+        sn_eps=1e-8,
+        sn_style='torch',
+        split_noise=False,
+        auto_sync_bn=False,
+        init_cfg=dict(type='N02')),
+    discriminator=dict(
+        type=BigGANDiscriminator,
+        input_scale=32,
+        num_classes=10,
+        base_channels=64,
+        sn_eps=1e-8,
+        sn_style='torch',
+        with_spectral_norm=True,
+        init_cfg=dict(type='N02')),
+    generator_steps=1,
+    discriminator_steps=4,
+    ema_config=ema_config)
+
+# define dataset
+train_dataloader = dict(batch_size=25, num_workers=8)
+val_dataloader = dict(batch_size=25, num_workers=8)
+test_dataloader = dict(batch_size=25, num_workers=8)
+
+# VIS_HOOK
+custom_hooks = [
+    dict(
+        type=VisualizationHook,
+        interval=5000,
+        fixed_input=True,
+        # vis ema and orig at the same time
+        vis_kwargs_list=dict(
+            type='Noise',
+            name='fake_img',
+            sample_model='ema/orig',
+            target_keys=['ema', 'orig'])),
+]
+
+optim_wrapper = dict(
+    generator=dict(optimizer=dict(type='Adam', lr=0.0002, betas=(0.0, 0.999))),
+    discriminator=dict(
+        optimizer=dict(type='Adam', lr=0.0002, betas=(0.0, 0.999))))
+train_cfg = dict(max_iters=500000)
+
+metrics = [
+    dict(
+        type=FrechetInceptionDistance,
+        prefix='FID-Full-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema'),
+    dict(
+        type='IS',
+        prefix='IS-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema')
+]
+# save multi best checkpoints
+default_hooks = dict(
+    checkpoint=dict(
+        save_best=['FID-Full-50k/fid', 'IS-50k/is'], rule=['less', 'greater']))
+
+val_evaluator = dict(metrics=metrics)
+test_evaluator = dict(metrics=metrics)

--- a/mmagic/configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 from mmengine.config import read_base
 
 from mmagic.engine import VisualizationHook

--- a/mmagic/configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py
@@ -5,9 +5,9 @@ from mmagic.engine import VisualizationHook
 from mmagic.evaluation.metrics import FrechetInceptionDistance
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
-    from .._base_.gen_default_runtime import *  # noqa: F401,F403
-    from .._base_.models.biggan.base_biggan_128x128 import *  # noqa: F401,F403
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
+    from .._base_.models.biggan.base_biggan_128x128 import *
 
 # define model
 ema_config = dict(

--- a/mmagic/configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py
@@ -5,9 +5,9 @@ from mmagic.engine import VisualizationHook
 from mmagic.evaluation.metrics import FrechetInceptionDistance
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *
-    from .._base_.gen_default_runtime import *
-    from .._base_.models.biggan.base_biggan_128x128 import *
+    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
+    from .._base_.gen_default_runtime import *  # noqa: F401,F403
+    from .._base_.models.biggan.base_biggan_128x128 import *  # noqa: F401,F403
 
 # define model
 ema_config = dict(

--- a/mmagic/configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py
@@ -1,0 +1,69 @@
+from mmengine.config import read_base
+
+from mmagic.engine import VisualizationHook
+from mmagic.evaluation.metrics import FrechetInceptionDistance
+
+with read_base():
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
+    from .._base_.models.biggan.base_biggan_128x128 import *
+
+# define model
+ema_config = dict(
+    type='ExponentialMovingAverage',
+    interval=1,
+    momentum=0.0001,
+    update_buffers=True,
+    start_iter=20000)
+
+model = dict(ema_config=ema_config)
+train_cfg = dict(max_iters=1500000)
+
+# define dataset
+train_dataloader = dict(
+    batch_size=32, num_workers=8, dataset=dict(data_root='data/imagenet'))
+
+# define optimizer
+optim_wrapper = dict(
+    generator=dict(
+        accumulative_counts=8,
+        optimizer=dict(type='Adam', lr=0.0001, betas=(0.0, 0.999), eps=1e-6)),
+    discriminator=dict(
+        accumulative_counts=8,
+        optimizer=dict(type='Adam', lr=0.0004, betas=(0.0, 0.999), eps=1e-6)))
+
+# VIS_HOOK
+custom_hooks = [
+    dict(
+        type=VisualizationHook,
+        interval=10000,
+        fixed_input=True,
+        # vis ema and orig at the same time
+        vis_kwargs_list=dict(
+            type='Noise',
+            name='fake_img',
+            sample_model='ema/orig',
+            target_keys=['ema', 'orig'])),
+]
+
+metrics = [
+    dict(
+        type=FrechetInceptionDistance,
+        prefix='FID-Full-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema'),
+    dict(
+        type='IS',
+        prefix='IS-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema')
+]
+# save multi best checkpoints
+default_hooks = dict(
+    checkpoint=dict(
+        save_best=['FID-Full-50k/fid', 'IS-50k/is'], rule=['less', 'greater']))
+
+val_evaluator = dict(metrics=metrics)
+test_evaluator = dict(metrics=metrics)

--- a/mmagic/configs/biggan/biggan_cvt-BigGAN-PyTorch-rgb_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan_cvt-BigGAN-PyTorch-rgb_imagenet1k-128x128.py
@@ -7,8 +7,8 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
                                           BigGANGenerator)
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *
-    from .._base_.gen_default_runtime import *
+    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
+    from .._base_.gen_default_runtime import *  # noqa: F401,F403
 
 ema_config = dict(
     type='ExponentialMovingAverage',

--- a/mmagic/configs/biggan/biggan_cvt-BigGAN-PyTorch-rgb_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan_cvt-BigGAN-PyTorch-rgb_imagenet1k-128x128.py
@@ -7,8 +7,8 @@ from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
                                           BigGANGenerator)
 
 with read_base():
-    from .._base_.datasets.imagenet_noaug_128 import *  # noqa: F401,F403
-    from .._base_.gen_default_runtime import *  # noqa: F401,F403
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
 
 ema_config = dict(
     type='ExponentialMovingAverage',

--- a/mmagic/configs/biggan/biggan_cvt-BigGAN-PyTorch-rgb_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan_cvt-BigGAN-PyTorch-rgb_imagenet1k-128x128.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 from mmengine.config import read_base
 
 from mmagic.evaluation.metrics import FrechetInceptionDistance

--- a/mmagic/configs/biggan/biggan_cvt-BigGAN-PyTorch-rgb_imagenet1k-128x128.py
+++ b/mmagic/configs/biggan/biggan_cvt-BigGAN-PyTorch-rgb_imagenet1k-128x128.py
@@ -1,0 +1,65 @@
+from mmengine.config import read_base
+
+from mmagic.evaluation.metrics import FrechetInceptionDistance
+from mmagic.models.data_preprocessors import DataPreprocessor
+from mmagic.models.editors.biggan import (BigGAN, BigGANDiscriminator,
+                                          BigGANGenerator)
+
+with read_base():
+    from .._base_.datasets.imagenet_noaug_128 import *
+    from .._base_.gen_default_runtime import *
+
+ema_config = dict(
+    type='ExponentialMovingAverage',
+    interval=1,
+    momentum=0.0001,
+    update_buffers=True,
+    start_iter=20000)
+
+model = dict(
+    type=BigGAN,
+    num_classes=1000,
+    data_preprocessor=dict(type=DataPreprocessor),
+    ema_config=ema_config,
+    generator=dict(
+        type=BigGANGenerator,
+        output_scale=128,
+        noise_size=120,
+        num_classes=1000,
+        base_channels=96,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        act_cfg=dict(type='ReLU', inplace=True),
+        split_noise=True,
+        auto_sync_bn=False,
+        rgb2bgr=True,
+        init_cfg=dict(type='ortho')),
+    discriminator=dict(
+        type=BigGANDiscriminator,
+        input_scale=128,
+        num_classes=1000,
+        base_channels=96,
+        sn_eps=1e-6,
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True,
+        init_cfg=dict(type='ortho')))
+
+train_cfg = train_dataloader = optim_wrapper = None
+
+metrics = [
+    dict(
+        type=FrechetInceptionDistance,
+        prefix='FID-Full-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema'),
+    dict(
+        type='IS',
+        prefix='IS-50k',
+        fake_nums=50000,
+        inception_style='StyleGAN',
+        sample_model='ema')
+]
+val_evaluator = dict(metrics=metrics)
+test_evaluator = dict(metrics=metrics)


### PR DESCRIPTION
Adapting New Version of config Adapting  BigGAN Algorithm, based on open-mmlab/OpenMMLabCamp#643

## Motivation

MMEngine has introduced a novel configuration mechanism, utilizing which we will perform configuration file adaptation.

## Modification

* Add 2 config python files in mmagic/configs/_base_/datasets/
* Add 6 config python files in mmagic/configs/biggan/
* Add 1 config python files inmmagic/configs/_base_/models/biggan/  


The output of `config_validate.py`:
![1693126306548](https://github.com/open-mmlab/mmagic/assets/98383074/39211c3b-3885-43f6-a209-f5dea2da5661)  
The output of `demo.py`:
![1693126602779](https://github.com/open-mmlab/mmagic/assets/98383074/db59e882-177e-449b-957a-a6f8cf0f841c)
![1693126629996](https://github.com/open-mmlab/mmagic/assets/98383074/71657c0c-a909-420a-b768-7298196be0c2)

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.