### PR TITLE
[Enhance] add negative prompt for sd inferencer

### DIFF
--- a/mmagic/apis/inferencers/text2image_inferencer.py
+++ b/mmagic/apis/inferencers/text2image_inferencer.py
@@ -15,18 +15,23 @@ class Text2ImageInferencer(BaseMMagicInferencer):
     """inferencer that predicts with text2image models."""
 
     func_kwargs = dict(
-        preprocess=['text', 'control'],
+        preprocess=['text', 'control', 'negative_prompt'],
         forward=[],
         visualize=['result_out_dir'],
         postprocess=[])
 
     extra_parameters = dict(height=None, width=None, seed=1)
 
-    def preprocess(self, text: InputsType, control: str = None) -> Dict:
+    def preprocess(self,
+                   text: InputsType,
+                   control: str = None,
+                   negative_prompt: InputsType = None) -> Dict:
         """Process the inputs into a model-feedable format.
 
         Args:
             text(InputsType): text input for text-to-image model.
+            control(str): control img dir for controlnet.
+            negative_prompt(InputsType): negative prompt.
 
         Returns:
             result(Dict): Results of preprocess.
@@ -42,6 +47,9 @@ class Text2ImageInferencer(BaseMMagicInferencer):
             control_img = fromarray(control_img)
             result['control'] = control_img
             result.pop('seed', None)
+
+        if negative_prompt:
+            result['negative_prompt'] = negative_prompt
 
         return result
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

To use negative prompt in text2image inferencer:

```python
from mmagic.apis import MMagicInferencer

# Create a MMEdit instance and infer
editor = MMagicInferencer(model_name='stable_diffusion')
text_prompts = 'A old man standing by the sea, perfect'
negative_prompt = 'bad hands, bad face'
result_out_dir = 'resources/output/text2image/sd_res0910.png'
editor.infer(text=text_prompts,
             negative_prompt=negative_prompt,
             result_out_dir=result_out_dir)
```

## Checklist

Submitting this pull request means that,

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
