### PR TITLE
[Feature] Support inference with diffusers pipeline, sd_xl first.

### DIFF
--- a/configs/diffusers_pipeline/README.md
+++ b/configs/diffusers_pipeline/README.md
@@ -1,0 +1,47 @@
+# Diffusers Pipeline (2023)
+
+> [Diffusers Pipeline](https://github.com/huggingface/diffusers)
+
+> **Task**: Diffusers Pipeline
+
+<!-- [ALGORITHM] -->
+
+## Abstract
+
+<!-- [ABSTRACT] -->
+
+We support diffusers pipelines for users to conveniently use diffusers to do inferece in our repo.
+
+## Configs
+
+|                   Model                   | Dataset | Download |
+| :---------------------------------------: | :-----: | :------: |
+| [diffusers pipeline](./sd_xl_pipeline.py) |    -    |    -     |
+
+## Quick Start
+
+```python
+from mmagic.apis import MMagicInferencer
+
+# Create a MMEdit instance and infer
+editor = MMagicInferencer(model_name='diffusers_pipeline')
+text_prompts = 'Japanese anime style, girl, beautiful, cute, colorful, best quality, extremely detailed'
+negative_prompt = 'bad face, bad hands'
+result_out_dir = 'resources/output/text2image/sd_xl_japanese.png'
+editor.infer(text=text_prompts,
+             negative_prompt=negative_prompt,
+             result_out_dir=result_out_dir)
+```
+
+## Citation
+
+```bibtex
+@misc{von-platen-etal-2022-diffusers,
+  author = {Patrick von Platen and Suraj Patil and Anton Lozhkov and Pedro Cuenca and Nathan Lambert and Kashif Rasul and Mishig Davaadorj and Thomas Wolf},
+  title = {Diffusers: State-of-the-art diffusion models},
+  year = {2022},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/huggingface/diffusers}}
+}
+```

--- a/configs/diffusers_pipeline/README.md
+++ b/configs/diffusers_pipeline/README.md
@@ -10,7 +10,7 @@
 
 <!-- [ABSTRACT] -->
 
-We support diffusers pipelines for users to conveniently use diffusers to do inferece in our repo.
+For the convenience of our community users, this inferencer supports using the pipelines from diffusers for inference to compare the results with the algorithms supported within our algorithm library.
 
 ## Configs
 
@@ -20,6 +20,10 @@ We support diffusers pipelines for users to conveniently use diffusers to do inf
 
 ## Quick Start
 
+### sd_xl_pipeline
+
+To run stable diffusion XL with mmagic inference API, follow these codes:
+
 ```python
 from mmagic.apis import MMagicInferencer
 
@@ -27,11 +31,17 @@ from mmagic.apis import MMagicInferencer
 editor = MMagicInferencer(model_name='diffusers_pipeline')
 text_prompts = 'Japanese anime style, girl, beautiful, cute, colorful, best quality, extremely detailed'
 negative_prompt = 'bad face, bad hands'
-result_out_dir = 'resources/output/text2image/sd_xl_japanese.png'
+result_out_dir = 'sd_xl_japanese.png'
 editor.infer(text=text_prompts,
              negative_prompt=negative_prompt,
              result_out_dir=result_out_dir)
 ```
+
+You will get this picture:
+
+<div align=center >
+ <img src="https://user-images.githubusercontent.com/12782558/266557074-53519887-6597-42cf-8a0b-03c2db3f4ab2.png" width="600"/>
+</div >
 
 ## Citation
 

--- a/configs/diffusers_pipeline/metafile.yml
+++ b/configs/diffusers_pipeline/metafile.yml
@@ -1,0 +1,17 @@
+Collections:
+- Name: Diffusers Pipeline
+  Paper:
+    Title: Diffusers Pipeline
+    URL: https://github.com/huggingface/diffusers
+  README: configs/diffusers_pipeline/README.md
+  Task:
+  - diffusers pipeline
+  Year: 2023
+Models:
+- Config: configs/diffusers_pipeline/sd_xl_pipeline.py
+  In Collection: Diffusers Pipeline
+  Name: sd_xl_pipeline
+  Results:
+  - Dataset: '-'
+    Metrics: {}
+    Task: Diffusers Pipeline

--- a/configs/diffusers_pipeline/sd_xl_pipeline.py
+++ b/configs/diffusers_pipeline/sd_xl_pipeline.py
@@ -2,5 +2,4 @@
 
 model = dict(
     type='DiffusionPipeline',
-    from_pretrained='stabilityai/stable-diffusion-xl-base-1.0'
-)
+    from_pretrained='stabilityai/stable-diffusion-xl-base-1.0')

--- a/configs/diffusers_pipeline/sd_xl_pipeline.py
+++ b/configs/diffusers_pipeline/sd_xl_pipeline.py
@@ -1,0 +1,6 @@
+# config for model
+
+model = dict(
+    type='DiffusionPipeline',
+    from_pretrained='stabilityai/stable-diffusion-xl-base-1.0'
+)

--- a/mmagic/apis/inferencers/__init__.py
+++ b/mmagic/apis/inferencers/__init__.py
@@ -7,6 +7,7 @@ from mmagic.utils import ConfigType
 from .colorization_inferencer import ColorizationInferencer
 from .conditional_inferencer import ConditionalInferencer
 from .controlnet_animation_inferencer import ControlnetAnimationInferencer
+from .diffusers_pipeline_inferencer import DiffusersPipelineInferencer
 from .eg3d_inferencer import EG3DInferencer
 from .image_super_resolution_inferencer import ImageSuperResolutionInferencer
 from .inpainting_inferencer import InpaintingInferencer
@@ -23,7 +24,7 @@ __all__ = [
     'ImageSuperResolutionInferencer', 'Text2ImageInferencer',
     'TranslationInferencer', 'UnconditionalInferencer',
     'VideoInterpolationInferencer', 'VideoRestorationInferencer',
-    'ControlnetAnimationInferencer'
+    'ControlnetAnimationInferencer', 'DiffusersPipelineInferencer'
 ]
 
 
@@ -90,6 +91,9 @@ class Inferencers:
                 'artifact reduction', 'Deblurring'
         ]:
             self.inferencer = ImageSuperResolutionInferencer(
+                config, ckpt, device, extra_parameters, seed=seed)
+        elif self.task in ['Diffusers Pipeline']:
+            self.inferencer = DiffusersPipelineInferencer(
                 config, ckpt, device, extra_parameters, seed=seed)
         else:
             raise ValueError(f'Unknown inferencer task: {self.task}')

--- a/mmagic/apis/inferencers/base_mmagic_inferencer.py
+++ b/mmagic/apis/inferencers/base_mmagic_inferencer.py
@@ -130,10 +130,10 @@ class BaseMMagicInferencer(BaseInferencer):
         Returns:
             Union[Dict, List[Dict]]: Results of inference pipeline.
         """
-        if 'extra_parameters' in kwargs.keys():
-            if 'infer_with_grad' in kwargs['extra_parameters'].keys():
-                if kwargs['extra_parameters']['infer_with_grad']:
-                    results = self.base_call(**kwargs)
+        if ('extra_parameters' in kwargs.keys()
+                and 'infer_with_grad' in kwargs['extra_parameters'].keys()
+                and kwargs['extra_parameters']['infer_with_grad']):
+            results = self.base_call(**kwargs)
         else:
             with torch.no_grad():
                 results = self.base_call(**kwargs)

--- a/mmagic/apis/inferencers/diffusers_pipeline_inferencer.py
+++ b/mmagic/apis/inferencers/diffusers_pipeline_inferencer.py
@@ -1,0 +1,73 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import os
+from typing import Dict, List
+
+import numpy as np
+from mmengine import mkdir_or_exist
+from PIL.Image import Image
+from torchvision.utils import save_image
+
+from .base_mmagic_inferencer import BaseMMagicInferencer, InputsType, PredType
+
+
+class DiffusersPipelineInferencer(BaseMMagicInferencer):
+    """inferencer that predicts with text2image models."""
+
+    func_kwargs = dict(
+        preprocess=['text', 'negative_prompt'],
+        forward=[],
+        visualize=['result_out_dir'],
+        postprocess=[])
+
+    extra_parameters = dict(height=None, width=None)
+
+    def preprocess(self,
+                   text: InputsType,
+                   negative_prompt: InputsType = None) -> Dict:
+        """Process the inputs into a model-feedable format.
+
+        Args:
+            text(InputsType): text input for text-to-image model.
+            negative_prompt(InputsType): negative prompt.
+
+        Returns:
+            result(Dict): Results of preprocess.
+        """
+        result = self.extra_parameters
+        result['prompt'] = text
+
+        if negative_prompt:
+            result['negative_prompt'] = negative_prompt
+
+        return result
+
+    def forward(self, inputs: InputsType) -> PredType:
+        """Forward the inputs to the model."""
+        images = self.model(**inputs).images
+
+        return images
+
+    def visualize(self,
+                  preds: PredType,
+                  result_out_dir: str = None) -> List[np.ndarray]:
+        """Visualize predictions.
+
+        Args:
+            preds (List[Union[str, np.ndarray]]): Forward results
+                by the inferencer.
+            result_out_dir (str): Output directory of image.
+                Defaults to ''.
+
+        Returns:
+            List[np.ndarray]: Result of visualize
+        """
+        if result_out_dir:
+            mkdir_or_exist(os.path.dirname(result_out_dir))
+            if type(preds) is list:
+                preds = preds[0]
+            if type(preds) is Image:
+                preds.save(result_out_dir)
+            else:
+                save_image(preds, result_out_dir, normalize=True)
+
+        return preds

--- a/mmagic/apis/inferencers/diffusers_pipeline_inferencer.py
+++ b/mmagic/apis/inferencers/diffusers_pipeline_inferencer.py
@@ -14,16 +14,19 @@ class DiffusersPipelineInferencer(BaseMMagicInferencer):
     """inferencer that predicts with text2image models."""
 
     func_kwargs = dict(
-        preprocess=['text', 'negative_prompt'],
+        preprocess=[
+            'text', 'negative_prompt', 'num_inference_steps', 'height', 'width'
+        ],
         forward=[],
         visualize=['result_out_dir'],
         postprocess=[])
 
-    extra_parameters = dict(height=None, width=None)
-
     def preprocess(self,
                    text: InputsType,
-                   negative_prompt: InputsType = None) -> Dict:
+                   negative_prompt: InputsType = None,
+                   num_inference_steps: int = 20,
+                   height=None,
+                   width=None) -> Dict:
         """Process the inputs into a model-feedable format.
 
         Args:
@@ -35,9 +38,14 @@ class DiffusersPipelineInferencer(BaseMMagicInferencer):
         """
         result = self.extra_parameters
         result['prompt'] = text
-
         if negative_prompt:
             result['negative_prompt'] = negative_prompt
+        if num_inference_steps:
+            result['num_inference_steps'] = num_inference_steps
+        if height:
+            result['height'] = height
+        if width:
+            result['width'] = width
 
         return result
 

--- a/mmagic/apis/mmagic_inferencer.py
+++ b/mmagic/apis/mmagic_inferencer.py
@@ -114,11 +114,14 @@ class MMagicInferencer:
         # 3D-aware generation
         'eg3d',
 
-        # diffusers inferencer
+        # animation inferencer
         'controlnet_animation',
 
         # draggan
-        'draggan'
+        'draggan',
+
+        # diffusers pipeline inferencer
+        'diffusers_pipeline',
     ]
 
     inference_supported_models_cfg = {}

--- a/mmagic/models/archs/__init__.py
+++ b/mmagic/models/archs/__init__.py
@@ -63,10 +63,21 @@ def register_diffusers_models() -> List[str]:
             wrapped_module = gen_wrapped_cls(module, module_name)
             MODELS.register_module(name=module_name, module=wrapped_module)
             DIFFUSERS_MODELS.append(module_name)
-    return DIFFUSERS_MODELS
+
+    DIFFUSERS_PIPELINES = []
+    for pipeline_name in dir(diffusers.pipelines):
+        pipeline = getattr(diffusers.pipelines, pipeline_name)
+        if (inspect.isclass(pipeline)
+                and issubclass(pipeline, diffusers.DiffusionPipeline)):
+            wrapped_pipeline = gen_wrapped_cls(pipeline, pipeline_name)
+            MODELS.register_module(name=pipeline_name, module=wrapped_pipeline)
+            DIFFUSERS_PIPELINES.append(pipeline_name)
+
+    return DIFFUSERS_MODELS, DIFFUSERS_PIPELINES
 
 
-REGISTERED_DIFFUSERS_MODELS = register_diffusers_models()
+REGISTERED_DIFFUSERS_MODELS, REGISTERED_DIFFUSERS_PIPELINES = \
+    register_diffusers_models()
 
 __all__ = [
     'ASPP', 'DepthwiseSeparableConvModule', 'SimpleGatedConvModule',

--- a/mmagic/models/archs/wrapper.py
+++ b/mmagic/models/archs/wrapper.py
@@ -177,3 +177,11 @@ class DiffusersWrapper(BaseModule):
             Any: The output of wrapped module's forward function.
         """
         return self.model(*args, **kwargs)
+
+    def to(
+        self,
+        torch_device: Optional[Union[str, torch.device]] = None,
+        torch_dtype: Optional[torch.dtype] = None,
+    ):
+        self.model.to(torch_device, torch_dtype)
+        return self

--- a/mmagic/models/archs/wrapper.py
+++ b/mmagic/models/archs/wrapper.py
@@ -183,6 +183,18 @@ class DiffusersWrapper(BaseModule):
         torch_device: Optional[Union[str, torch.device]] = None,
         torch_dtype: Optional[torch.dtype] = None,
     ):
+        """Put wrapped module to device or convert it to torch_dtype. There are
+        two to() function. One is nn.module.to() and the other is
+        diffusers.pipeline.to(), if both args are passed,
+        diffusers.pipeline.to() is called.
+
+        Args:
+            torch_device: The device to put to.
+            torch_dtype: The type to convert to.
+
+        Returns:
+            self: the wrapped module itself.
+        """
         if torch_dtype is None:
             self.model.to(torch_device)
         else:

--- a/mmagic/models/archs/wrapper.py
+++ b/mmagic/models/archs/wrapper.py
@@ -183,5 +183,8 @@ class DiffusersWrapper(BaseModule):
         torch_device: Optional[Union[str, torch.device]] = None,
         torch_dtype: Optional[torch.dtype] = None,
     ):
-        self.model.to(torch_device, torch_dtype)
+        if torch_dtype is None:
+            self.model.to(torch_device)
+        else:
+            self.model.to(torch_device, torch_dtype)
         return self

--- a/model-index.yml
+++ b/model-index.yml
@@ -12,6 +12,7 @@ Import:
 - configs/deepfillv1/metafile.yml
 - configs/deepfillv2/metafile.yml
 - configs/dic/metafile.yml
+- configs/diffusers_pipeline/metafile.yml
 - configs/dim/metafile.yml
 - configs/disco_diffusion/metafile.yml
 - configs/draggan/metafile.yml

--- a/tests/test_apis/test_inferencers/test_diffusers_pipeline_inferencer.py
+++ b/tests/test_apis/test_inferencers/test_diffusers_pipeline_inferencer.py
@@ -1,0 +1,40 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+import platform
+from mmengine.utils import digit_version
+from mmengine.utils.dl_utils import TORCH_VERSION
+
+from mmagic.apis.inferencers.diffusers_pipeline_inferencer import \
+    DiffusersPipelineInferencer
+from mmagic.utils import register_all_modules
+
+register_all_modules()
+
+
+@pytest.mark.skipif(
+    'win' in platform.system().lower()
+    or digit_version(TORCH_VERSION) <= digit_version('1.8.1'),
+    reason='skip on windows due to limited RAM'
+    'and get_submodule requires torch >= 1.9.0')
+def test_diffusers_pipeline_inferencer():
+    cfg = dict(
+        model=dict(
+            type='DiffusionPipeline',
+            from_pretrained='runwayml/stable-diffusion-v1-5'))
+
+    inferencer_instance = DiffusersPipelineInferencer(cfg, None)
+    text_prompts = 'Japanese anime style, girl'
+    negative_prompt = 'bad face, bad hands'
+    result = inferencer_instance(
+        text=text_prompts,
+        negative_prompt=negative_prompt,
+        height=128,
+        width=128)
+    assert result[1][0].size == (128, 128)
+
+
+def teardown_module():
+    import gc
+    gc.collect()
+    globals().clear()
+    locals().clear()

--- a/tests/test_apis/test_inferencers/test_diffusers_pipeline_inferencer.py
+++ b/tests/test_apis/test_inferencers/test_diffusers_pipeline_inferencer.py
@@ -29,9 +29,9 @@ def test_diffusers_pipeline_inferencer():
     result = inferencer_instance(
         text=text_prompts,
         negative_prompt=negative_prompt,
-        height=128,
-        width=128)
-    assert result[1][0].size == (128, 128)
+        height=64,
+        width=64)
+    assert result[1][0].size == (64, 64)
 
 
 def teardown_module():

--- a/tests/test_apis/test_inferencers/test_diffusers_pipeline_inferencer.py
+++ b/tests/test_apis/test_inferencers/test_diffusers_pipeline_inferencer.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import pytest
 import platform
+
+import pytest
 from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

```python
from mmagic.apis import MMagicInferencer

# Create a MMEdit instance and infer
editor = MMagicInferencer(model_name='diffusers_pipeline')
text_prompts = 'Japanese anime style, girl, beautiful, cute, colorful, best quality, extremely detailed'
negative_prompt = 'bad face, bad hands'
result_out_dir = 'resources/output/text2image/sd_xl_japanese.png'
editor.infer(text=text_prompts,
             negative_prompt=negative_prompt,
             result_out_dir=result_out_dir)
```

and you will get this
![sd_xl_japanese](https://github.com/open-mmlab/mmagic/assets/12782558/53519887-6597-42cf-8a0b-03c2db3f4ab2)



## Checklist

Submitting this pull request means that,

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
