### PR TITLE
[Enhance] Add ‘config_name' as a supplement to the 'model_setting'

### DIFF
--- a/demo/mmagic_inference_demo.py
+++ b/demo/mmagic_inference_demo.py
@@ -44,6 +44,11 @@ def parse_args():
         default=None,
         help='Pretrained mmagic algorithm setting')
     parser.add_argument(
+        '--config-name',
+        type=str,
+        default=None,
+        help='Pretrained mmagic algorithm config name')
+    parser.add_argument(
         '--model-config',
         type=str,
         default=None,

--- a/demo/mmagic_inference_tutorial.ipynb
+++ b/demo/mmagic_inference_tutorial.ipynb
@@ -404,9 +404,13 @@
     "\n",
     "There are some different configs and checkpoints for one model.\n",
     "\n",
+    "You could configure different settings by passing 'model_setting' to 'MMagicInferencer'. Every model's default setting is 0.\n",
+    "\n",
     "Take conditional GAN model 'biggan' as an example. We have pretrained model for Cifar and Imagenet, and all pretrained models of 'biggan' are listed in its [metafile.yaml](../configs/biggan/metafile.yml)\n",
     "\n",
-    "You could configure different settings by passing 'model_setting' to 'MMagicInferencer'. Every model's default setting is 0."
+    "There are six settings in this metafile. If you choose setting 1, then the config 'configs/biggan/biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128.py' will be used. If 'model_setting' is not passed to 'MMagicInferencer', the config ‘configs/biggan/biggan_2xb25-500kiters_cifar10-32x32.py’ will be used by default.\n",
+    "\n",
+    "And you could also use 'config_name' to replace 'model_setting'. For example, you can init a MMagicInferencer with 'MMagicInferencer('biggan', config_name='biggan_2xb25-500kiters_cifar10-32x32')', which is the same with 'MMagicInferencer('biggan', model_setting=0)'."
    ]
   },
   {

--- a/mmagic/apis/inferencers/diffusers_pipeline_inferencer.py
+++ b/mmagic/apis/inferencers/diffusers_pipeline_inferencer.py
@@ -22,7 +22,7 @@ class DiffusersPipelineInferencer(BaseMMagicInferencer):
         postprocess=[])
 
     def preprocess(self,
-                   text: InputsType,
+                   text: InputsType = None,
                    negative_prompt: InputsType = None,
                    num_inference_steps: int = 20,
                    height=None,
@@ -37,7 +37,8 @@ class DiffusersPipelineInferencer(BaseMMagicInferencer):
             result(Dict): Results of preprocess.
         """
         result = self.extra_parameters
-        result['prompt'] = text
+        if text:
+            result['prompt'] = text
         if negative_prompt:
             result['negative_prompt'] = negative_prompt
         if num_inference_steps:

--- a/mmagic/apis/mmagic_inferencer.py
+++ b/mmagic/apis/mmagic_inferencer.py
@@ -130,6 +130,7 @@ class MMagicInferencer:
     def __init__(self,
                  model_name: str = None,
                  model_setting: int = None,
+                 config_name: int = None,
                  model_config: str = None,
                  model_ckpt: str = None,
                  device: torch.device = None,
@@ -141,13 +142,14 @@ class MMagicInferencer:
         inferencer_kwargs = {}
         inferencer_kwargs.update(
             self._get_inferencer_kwargs(model_name, model_setting,
-                                        model_config, model_ckpt,
-                                        extra_parameters))
+                                        config_name, model_config,
+                                        model_ckpt, extra_parameters))
         self.inferencer = Inferencers(
             device=device, seed=seed, **inferencer_kwargs)
 
     def _get_inferencer_kwargs(self, model_name: Optional[str],
                                model_setting: Optional[int],
+                               config_name: Optional[int],
                                model_config: Optional[str],
                                model_ckpt: Optional[str],
                                extra_parameters: Optional[Dict]) -> Dict:
@@ -161,6 +163,11 @@ class MMagicInferencer:
             if model_setting:
                 setting_to_use = model_setting
             config_dir = cfgs['settings'][setting_to_use]['Config']
+            if config_name:
+                for setting in cfgs['settings']:
+                    if setting['Name'] == config_name:
+                        config_dir = setting['Config']
+                        break
             config_dir = config_dir[config_dir.find('configs'):]
             if osp.exists(
                     osp.join(osp.dirname(__file__), '..', '..', config_dir)):

--- a/mmagic/apis/mmagic_inferencer.py
+++ b/mmagic/apis/mmagic_inferencer.py
@@ -141,9 +141,9 @@ class MMagicInferencer:
         MMagicInferencer.init_inference_supported_models_cfg()
         inferencer_kwargs = {}
         inferencer_kwargs.update(
-            self._get_inferencer_kwargs(model_name, model_setting,
-                                        config_name, model_config,
-                                        model_ckpt, extra_parameters))
+            self._get_inferencer_kwargs(model_name, model_setting, config_name,
+                                        model_config, model_ckpt,
+                                        extra_parameters))
         self.inferencer = Inferencers(
             device=device, seed=seed, **inferencer_kwargs)
 

--- a/tests/test_apis/test_inferencers/test_diffusers_pipeline_inferencer.py
+++ b/tests/test_apis/test_inferencers/test_diffusers_pipeline_inferencer.py
@@ -2,7 +2,6 @@
 import platform
 
 import pytest
-import torch
 from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
 
@@ -21,24 +20,11 @@ register_all_modules()
 def test_diffusers_pipeline_inferencer():
     cfg = dict(
         model=dict(
-            type='DiffusionPipeline',
-            from_pretrained='runwayml/stable-diffusion-v1-5'))
+            type='DiffusionPipeline', from_pretrained='google/ddpm-cat-256'))
 
     inferencer_instance = DiffusersPipelineInferencer(cfg, None)
-
-    def mock_infer(*args, **kwargs):
-        return dict(samples=torch.randn(1, 3, 64, 64))
-
-    inferencer_instance.model.infer = mock_infer
-
-    text_prompts = 'Japanese anime style, girl'
-    negative_prompt = 'bad face, bad hands'
-    result = inferencer_instance(
-        text=text_prompts,
-        negative_prompt=negative_prompt,
-        height=64,
-        width=64)
-    assert result[1][0].size == (64, 64)
+    result = inferencer_instance()
+    assert result[1][0].size == (256, 256)
 
 
 def teardown_module():


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

Some users complain that 'model_setting' is ambiguous， so we add 'config_name' as a supplement.

```python
import mmcv
import matplotlib.pyplot as plt
from mmagic.apis import MMagicInferencer

# configure setting to 1
editor = MMagicInferencer('biggan', model_setting=1) 
results = editor.infer(label=1)

# configure config_name is the same
editor = MMagicInferencer('biggan', config_name='biggan_ajbrock-sn_8xb32-1500kiters_imagenet1k-128x128') 
results = editor.infer(label=1)

```

## Checklist

Submitting this pull request means that,

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmagic/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
