### PR TITLE
Fix a test expression that has a logical short circuit.

### DIFF
--- a/mmagic/models/editors/stylegan2/stylegan2_discriminator.py
+++ b/mmagic/models/editors/stylegan2/stylegan2_discriminator.py
@@ -254,7 +254,7 @@ class ADAStyleGAN2Discriminator(StyleGAN2Discriminator):
                 augmentation. Defaults to None.
         """
         super().__init__(in_size, *args, **kwargs)
-        self.with_ada = data_aug is not None and data_aug is not dict()
+        self.with_ada = data_aug is not None and data_aug != dict()
         if self.with_ada:
             self.ada_aug = MODELS.build(data_aug)
             self.ada_aug.requires_grad = False


### PR DESCRIPTION
In file: stylegan2_discriminator.py, method: `__init__`, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not have identity an match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. 

The following binary operation

        data_aug is not dict()

compares a newly created object with the identity operator which will always evaluate to True.


I suggested that the logical operation should be reviewed for correctness. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.