### PR TITLE
[Fix] Support ndarray inputs in inpainting inferencer

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: Install mmagic dependencies
           command: |
-            pip install git+https://github.com/open-mmlab/mmengine.git@main
+            pip install 'mmengine >= 0.4.0, < 1.0.0'
             pip install -U openmim
             mim install 'mmcv >= 2.0.0, < 2.2.0'
             pip install -r requirements/tests.txt

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -70,7 +70,12 @@ jobs:
       - run:
           name: Run unittests
           command: |
-            coverage run --branch --source mmagic -m pytest tests/
+            # Run the large editor suite in batches so that objects retained by
+            # pytest plugins are released before the next batch starts.
+            coverage erase
+            coverage run --branch --source mmagic -m pytest tests/ --ignore=tests/test_models
+            coverage run --append --branch --source mmagic -m pytest tests/test_models --ignore=tests/test_models/test_editors
+            find tests/test_models/test_editors -mindepth 1 -maxdepth 1 -type d -print0 | sort -z | xargs -0 -n 15 coverage run --append --branch --source mmagic -m pytest
             coverage xml
             coverage report -m
   build_cuda:

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -61,7 +61,7 @@ jobs:
           command: |
             pip install git+https://github.com/open-mmlab/mmengine.git@main
             pip install -U openmim
-            mim install 'mmcv >= 2.0.0'
+            mim install 'mmcv >= 2.0.0, < 2.2.0'
             pip install -r requirements/tests.txt
       - run:
           name: Build and install

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ formats: [pdf, epub]
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.7"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ formats: [pdf, epub]
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.10"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: docs/en/conf.py
+
 formats: [pdf, epub]
 
 build:

--- a/mmagic/apis/inferencers/inpainting_inferencer.py
+++ b/mmagic/apis/inferencers/inpainting_inferencer.py
@@ -35,20 +35,56 @@ class InpaintingInferencer(BaseMMagicInferencer):
         Returns:
             results(Dict): Results of preprocess.
         """
-        infer_pipeline_cfg = [
-            dict(type='LoadImageFromFile', key='gt', channel_order='bgr'),
-            dict(
-                type='LoadMask',
-                mask_mode='file',
-            ),
+        infer_pipeline_cfg = []
+        inputs = dict()
+
+        if isinstance(img, np.ndarray):
+            img = img.copy()
+            if img.ndim == 2:
+                img = np.expand_dims(img, axis=2)
+            if img.ndim != 3 or img.shape[2] not in (1, 3):
+                raise ValueError('Image array must have shape (H, W), '
+                                 '(H, W, 1), or (H, W, 3), but got '
+                                 f'{img.shape}.')
+            inputs.update(
+                gt=img,
+                ori_gt_shape=img.shape,
+                gt_channel_order='bgr',
+                gt_color_type='grayscale' if img.shape[2] == 1 else 'color')
+        else:
+            inputs['gt_path'] = img
+            infer_pipeline_cfg.append(
+                dict(type='LoadImageFromFile', key='gt', channel_order='bgr'))
+
+        if isinstance(mask, np.ndarray):
+            mask = mask.copy()
+            if mask.ndim == 2:
+                mask = np.expand_dims(mask, axis=2)
+            elif mask.ndim == 3 and mask.shape[2] > 0:
+                mask = mask[:, :, 0:1]
+            else:
+                raise ValueError('Mask array must have shape (H, W) or '
+                                 '(H, W, C), where C is positive, but got '
+                                 f'{mask.shape}.')
+            mask[mask > 0] = 1.
+            inputs['mask'] = mask
+        else:
+            inputs['mask_path'] = mask
+            infer_pipeline_cfg.append(
+                dict(
+                    type='LoadMask',
+                    mask_mode='file',
+                ))
+
+        infer_pipeline_cfg.extend([
             dict(type='GetMaskedImage'),
             dict(type='PackInputs'),
-        ]
+        ])
 
         infer_pipeline = Compose(infer_pipeline_cfg)
 
         # prepare data
-        _data = infer_pipeline(dict(gt_path=img, mask_path=mask))
+        _data = infer_pipeline(inputs)
         data = dict()
         data['inputs'] = [_data['inputs']]
         data['data_samples'] = [_data['data_samples']]

--- a/mmagic/models/archs/tokenizer.py
+++ b/mmagic/models/archs/tokenizer.py
@@ -243,6 +243,7 @@ class TokenizerWrapper:
         Returns:
             Union[str, List[str]]: The decoded text.
         """
+        kwargs.setdefault('clean_up_tokenization_spaces', True)
         text = self.wrapped.decode(token_ids, *args, **kwargs)
         if return_raw:
             return text

--- a/projects/magicmaker/index.html
+++ b/projects/magicmaker/index.html
@@ -24,9 +24,9 @@
     </head>
     <body>
         <div class="space">
-            <iframe 
-                class="iframe" 
-                allowfullscreen="true" 
+            <iframe
+                class="iframe"
+                allowfullscreen="true"
                 frameborder="0"
                 src="https://openxlab.org.cn/magic-maker/home">
             </iframe>

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,7 +2,7 @@ av
 av==8.0.3; python_version < '3.7'
 click  # required by mmagic/utils/io_utils.py
 controlnet_aux
-diffusers>=0.23.0,<0.34.0
+diffusers>=0.23.0,<0.31.0
 einops
 face-alignment<=1.3.4
 facexlib

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,13 +2,13 @@ av
 av==8.0.3; python_version < '3.7'
 click  # required by mmagic/utils/io_utils.py
 controlnet_aux
-diffusers>=0.23.0
+diffusers>=0.23.0,<0.34.0
 einops
 face-alignment<=1.3.4
 facexlib
 lmdb
 lpips
-mediapipe
+mediapipe<1.0
 numpy
 # MMCV depends opencv-python instead of headless, thus we install opencv-python
 # Due to a bug from upstream, we skip this two version

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,7 +2,7 @@ av
 av==8.0.3; python_version < '3.7'
 click  # required by mmagic/utils/io_utils.py
 controlnet_aux
-diffusers>=0.23.0,<0.30.0
+diffusers>=0.23.0,<0.29.0
 einops
 face-alignment<=1.3.4
 facexlib

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,13 +2,14 @@ av
 av==8.0.3; python_version < '3.7'
 click  # required by mmagic/utils/io_utils.py
 controlnet_aux
-diffusers>=0.23.0,<0.31.0
+diffusers>=0.23.0,<0.30.0
 einops
 face-alignment<=1.3.4
 facexlib
 lmdb
 lpips
-mediapipe<1.0
+mediapipe<=0.10.11; python_version < '3.9'
+mediapipe<1.0; python_version >= '3.9'
 numpy
 # MMCV depends opencv-python instead of headless, thus we install opencv-python
 # Due to a bug from upstream, we skip this two version

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,6 +6,7 @@ diffusers>=0.23.0,<0.29.0
 einops
 face-alignment<=1.3.4
 facexlib
+huggingface-hub<0.26.0
 lmdb
 lpips
 mediapipe<=0.10.11; python_version < '3.9'

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -7,7 +7,7 @@ einops
 face-alignment<=1.3.4
 facexlib
 huggingface-hub<0.26.0
-lmdb
+lmdb<1.7
 lpips
 mediapipe<=0.10.11; python_version < '3.9'
 mediapipe<1.0; python_version >= '3.9'

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -12,5 +12,5 @@ coverage < 7.0.0
 imageio-ffmpeg==0.4.4
 interrogate
 mmdet >= 3.0.0
-pytest
+pytest<8
 transformers>=4.27.4

--- a/tests/test_apis/test_inferencers/test_inpainting_inferencer.py
+++ b/tests/test_apis/test_inferencers/test_inpainting_inferencer.py
@@ -1,6 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os.path as osp
 
+import mmcv
+import numpy as np
+import pytest
+import torch
+
 from mmagic.apis.inferencers.inpainting_inferencer import InpaintingInferencer
 from mmagic.utils import register_all_modules
 
@@ -26,10 +31,81 @@ def test_inpainting_inferencer():
     inferencer_instance = \
         InpaintingInferencer(cfg, None)
     inferencer_instance(img=masked_img_path, mask=mask_path)
+
+    rgb_img = mmcv.imread(masked_img_path, flag='color')[:, :, ::-1].copy()
+    img = rgb_img[:, :, ::-1]
+    mask = mmcv.imread(mask_path, flag='unchanged')
     inference_result = inferencer_instance(
-        img=masked_img_path, mask=mask_path, result_out_dir=result_out_dir)
+        img=img, mask=mask, result_out_dir=result_out_dir)
     result_img = inference_result[1]
     assert result_img.shape == (256, 256, 3)
+
+
+@pytest.mark.parametrize('img_as_array, mask_as_array', [
+    (True, True),
+    (True, False),
+    (False, True),
+])
+def test_inpainting_preprocess_array_inputs(img_as_array, mask_as_array):
+    data_root = osp.join(osp.dirname(__file__), '../../')
+    img_path = data_root + 'data/inpainting/celeba_test.png'
+    mask_path = data_root + 'data/inpainting/bbox_mask.png'
+    rgb_img = mmcv.imread(img_path, flag='color')[:, :, ::-1].copy()
+    img = rgb_img[:, :, ::-1]
+    mask = mmcv.imread(mask_path, flag='unchanged')
+    original_img = img.copy()
+    original_mask = mask.copy()
+
+    inferencer = object.__new__(InpaintingInferencer)
+    expected = inferencer.preprocess(img=img_path, mask=mask_path)
+    actual = inferencer.preprocess(
+        img=img if img_as_array else img_path,
+        mask=mask if mask_as_array else mask_path)
+
+    torch.testing.assert_close(actual['inputs'][0], expected['inputs'][0])
+    actual_sample = actual['data_samples'][0]
+    expected_sample = expected['data_samples'][0]
+    torch.testing.assert_close(actual_sample.gt_img, expected_sample.gt_img)
+    torch.testing.assert_close(actual_sample.mask, expected_sample.mask)
+
+    for key in [
+            'ori_gt_shape', 'gt_channel_order', 'gt_color_type',
+            'ori_img_shape', 'img_channel_order', 'img_color_type'
+    ]:
+        assert actual_sample.metainfo[key] == expected_sample.metainfo[key]
+
+    np.testing.assert_array_equal(img, original_img)
+    np.testing.assert_array_equal(mask, original_mask)
+
+
+def test_inpainting_preprocess_array_shapes():
+    img = np.zeros((4, 4), dtype=np.uint8)
+    mask = np.zeros((4, 4, 3), dtype=np.uint8)
+    mask[0, 0, 0] = 255
+    mask[1, 1, 1] = 255
+
+    inferencer = object.__new__(InpaintingInferencer)
+    result = inferencer.preprocess(img=img, mask=mask)
+    data_sample = result['data_samples'][0]
+
+    assert result['inputs'][0].shape == (1, 4, 4)
+    assert data_sample.gt_img.shape == (1, 4, 4)
+    assert data_sample.mask.shape == (1, 4, 4)
+    assert data_sample.gt_color_type == 'grayscale'
+    assert data_sample.mask[0, 0, 0] == 1
+    assert data_sample.mask[0, 1, 1] == 0
+
+
+@pytest.mark.parametrize('img, mask, match', [
+    (np.zeros((4, 4, 2)), np.zeros((4, 4)), 'Image array'),
+    (np.zeros((4, 4, 3, 1)), np.zeros((4, 4)), 'Image array'),
+    (np.zeros((4, 4, 3)), np.zeros((4, 4, 0)), 'Mask array'),
+    (np.zeros((4, 4, 3)), np.zeros((4, 4, 1, 1)), 'Mask array'),
+])
+def test_inpainting_preprocess_invalid_array_shapes(img, mask, match):
+    inferencer = object.__new__(InpaintingInferencer)
+    with pytest.raises(ValueError, match=match):
+        inferencer.preprocess(img=img, mask=mask)
 
 
 def teardown_module():

--- a/tests/test_models/test_editors/test_arcface/test_id_loss.py
+++ b/tests/test_models/test_editors/test_arcface/test_id_loss.py
@@ -1,10 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import platform
+from unittest.mock import patch
 
 import pytest
 import torch
 
 from mmagic.models import IDLossModel
+from mmagic.models.editors.arcface.model_irse import Backbone
+
+
+def get_mock_weights():
+    return Backbone(
+        input_size=112, num_layers=50, drop_ratio=0.6,
+        mode='ir_se').state_dict()
 
 
 class TestArcFace:
@@ -23,7 +31,10 @@ class TestArcFace:
         reason='skip on windows-cuda due to limited RAM.')
     def test_arcface_cpu(self):
         # test loss model
-        id_loss_model = IDLossModel()
+        with patch(
+                'torch.hub.load_state_dict_from_url',
+                return_value=get_mock_weights()):
+            id_loss_model = IDLossModel()
         x1 = torch.randn((2, 3, 224, 224))
         x2 = torch.randn((2, 3, 224, 224))
         y, _ = id_loss_model(pred=x1, gt=x2)
@@ -32,7 +43,10 @@ class TestArcFace:
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_arcface_cuda(self):
         # test loss model
-        id_loss_model = IDLossModel().cuda()
+        with patch(
+                'torch.hub.load_state_dict_from_url',
+                return_value=get_mock_weights()):
+            id_loss_model = IDLossModel().cuda()
         x1 = torch.randn((2, 3, 224, 224)).cuda()
         x2 = torch.randn((2, 3, 224, 224)).cuda()
         y, _ = id_loss_model(pred=x1, gt=x2)

--- a/tests/test_models/test_losses/test_face_id_loss.py
+++ b/tests/test_models/test_losses/test_face_id_loss.py
@@ -1,17 +1,28 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import platform
+from unittest.mock import patch
 
 import pytest
 import torch
 
+from mmagic.models.editors.arcface.model_irse import Backbone
 from mmagic.models.losses import FaceIdLoss
+
+
+def get_mock_weights():
+    return Backbone(
+        input_size=112, num_layers=50, drop_ratio=0.6,
+        mode='ir_se').state_dict()
 
 
 @pytest.mark.skipif(
     'win' in platform.system().lower() and 'cu' in torch.__version__,
     reason='skip on windows-cuda due to limited RAM.')
 def test_face_id_loss():
-    face_id_loss = FaceIdLoss(loss_weight=2.5)
+    with patch(
+            'torch.hub.load_state_dict_from_url',
+            return_value=get_mock_weights()):
+        face_id_loss = FaceIdLoss(loss_weight=2.5)
     assert face_id_loss.loss_weight == 2.5
     gt, pred = torch.randn(1, 3, 224, 224), torch.randn(1, 3, 224, 224)
     loss = face_id_loss(pred, gt)

--- a/tests/test_models/test_losses/test_loss_comps/test_face_id_loss_comps.py
+++ b/tests/test_models/test_losses/test_loss_comps/test_face_id_loss_comps.py
@@ -1,19 +1,30 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import platform
+from unittest.mock import patch
 
 import pytest
 import torch
 
 from mmagic.models import IDLossModel
+from mmagic.models.editors.arcface.model_irse import Backbone
 from mmagic.models.losses import FaceIdLossComps
+
+
+def get_mock_weights():
+    return Backbone(
+        input_size=112, num_layers=50, drop_ratio=0.6,
+        mode='ir_se').state_dict()
 
 
 @pytest.mark.skipif(
     'win' in platform.system().lower() and 'cu' in torch.__version__,
     reason='skip on windows-cuda due to limited RAM.')
 def test_face_id_loss_comps():
-    face_id_loss_comps = FaceIdLossComps(
-        loss_weight=2.5, data_info=dict(gt='real_imgs', pred='fake_imgs'))
+    with patch(
+            'torch.hub.load_state_dict_from_url',
+            return_value=get_mock_weights()):
+        face_id_loss_comps = FaceIdLossComps(
+            loss_weight=2.5, data_info=dict(gt='real_imgs', pred='fake_imgs'))
     assert isinstance(face_id_loss_comps.net, IDLossModel)
     data_dict = dict(
         a=1,


### PR DESCRIPTION
## Motivation

`InpaintingInferencer` declares `np.ndarray` as a supported input type, but its preprocessing pipeline always applies `LoadImageFromFile` and `LoadMask`. Arrays are therefore converted to strings and treated as file paths, which raises `OSError: File name too long`.

This fixes #1945.

## Modification

- Build the image and mask loading stages independently according to each input type, so path/array combinations are all supported.
- Prepare array metadata consistently with file-loaded images, copy non-contiguous image views before tensor conversion, and normalize array masks with the same first-channel and binary semantics as `LoadMask`.
- Reject unsupported image and mask array shapes with clear errors.
- Add regression coverage for full AOT-GAN inference with ndarray inputs, mixed path/array inputs, negative-stride BGR views, mask normalization, source-array immutability, and invalid shapes.

## BC-breaking

No. Existing path-based inputs keep the same loading pipeline and output.

## Test plan

- `pytest -q tests/test_apis/test_inferencers/test_inpainting_inferencer.py` (9 passed)
- Relevant loading, masked-image, packing, and data-preprocessor tests (19 passed)
- Target source coverage: 100%
- Pre-commit checks on both changed files: passed

## Checklist

- [x] I have read and followed the contribution workflow.
- [x] Pre-commit checks pass.
- [x] The bug is covered by unit and end-to-end inference tests.
- [x] The existing public input type already documents ndarray support; no separate documentation change is required.